### PR TITLE
createJavaScriptNode -> createScriptProcessor

### DIFF
--- a/public/js/AudioStreamer.js
+++ b/public/js/AudioStreamer.js
@@ -129,7 +129,7 @@ var AudioStreamer = (function() {
 
   var AudioSource = function() {
     this.buffer = [[], []];
-    this.js = audioContext.createJavaScriptNode(BUFFER_LENGTH, 2, 2);
+    this.js = audioContext.createScriptProcessor(BUFFER_LENGTH, 2, 2);
     this.js.onaudioprocess = this.onaudioprocess.bind(this);
     this.socket = null;
     this.getBufferCallback = null;


### PR DESCRIPTION
Fixes #7 for current versions of Chrome and Firefox.

See: https://developer.mozilla.org/en-US/docs/Web/API/AudioContext.createJavaScriptNode
